### PR TITLE
fix(activity): make user_id optional in Staff model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.22] - 2026-01-14
+
+### Fixed
+
+- Fixed Pydantic validation error in `StaffData.schedule_till`: field can now be `None` (moved to end of class to satisfy dataclass field ordering requirements)
+- Fixed Pydantic validation error in `ActivityResponse.data.staff.user_id`: field can now be `None` (moved to end of class to satisfy dataclass field ordering requirements)
+
 ## [0.1.6] - 2025-05-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poor_yclientsapi"
-version = "0.1.21"
+version = "0.1.22"
 description = "Poor collection of API methods for Yclients app"
 authors = ["Maksim Kosinov <mkosinov@mail.ru>"]
 license = "MIT"

--- a/src/yclientsapi/schema/activity.py
+++ b/src/yclientsapi/schema/activity.py
@@ -53,7 +53,6 @@ class Staff:
     company_id: int
     specialization: str
     api_id: str | None
-    user_id: int
     rating: float
     prepaid: str
     show_rating: int
@@ -62,6 +61,7 @@ class Staff:
     average_score: float
     avatar: str
     avatar_big: str
+    user_id: int | None = None
     position: dict[str, int | str] = field(default_factory=dict)
 
 


### PR DESCRIPTION
- Changed user_id type from int to int | None = None
- Moved user_id field to end of class to satisfy dataclass ordering
- Updated version to 0.1.22
- Updated CHANGELOG with fixes for schedule_till and user_id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes Pydantic dataclass parsing more permissive and resolves field ordering issues.
> 
> - In `activity.py`, change `Staff.user_id` to `int | None = None` and move it to the end of the class to satisfy dataclass field ordering
> - Bump version to `0.1.22` and update `CHANGELOG.md` (notes include fixes for optional `schedule_till` and `user_id`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca300b2bc996e469fece1f7ab3973c396ffaf447. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->