### PR TITLE
fix(staff): make google_link optional in StaffData schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poor_yclientsapi"
-version = "0.1.22"
+version = "0.1.24"
 description = "Poor collection of API methods for Yclients app"
 authors = ["Maksim Kosinov <mkosinov@mail.ru>"]
 license = "MIT"

--- a/src/yclientsapi/schema/staff.py
+++ b/src/yclientsapi/schema/staff.py
@@ -131,7 +131,7 @@ class StaffData:
     chain: Chain | None
     grid_settings: GridSettings
     domain: str | None
-    google_link: str
+    google_link: str | None = None
     schedule_till: str | None = None
 
 


### PR DESCRIPTION
## Summary

Fixes pydantic validation error when API YCLIENTS doesn't return `google_link` field in staff responses.

## Problem

Integration tests fail with:
```
pydantic_core._pydantic_core.ValidationError: 41 validation errors for StaffListResponse
data.0.google_link
  Field required [type=missing, input_value={...}, input_type=dict]
```

## Solution

Make `google_link` field optional (`str | None = None`) in `StaffData` schema, consistent with previous fixes for `schedule_till` and `user_id` fields (v0.1.22).

## Changes

- `src/yclientsapi/schema/staff.py`: `google_link: str` → `google_link: str | None = None`
- Bump version to `0.1.24`