### PR TITLE
fix(webhook): change custom_fields to dict | None in webhook schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poor_yclientsapi"
-version = "0.1.25"
+version = "0.1.26"
 description = "Poor collection of API methods for Yclients app"
 authors = ["Maksim Kosinov <mkosinov@mail.ru>"]
 license = "MIT"

--- a/src/yclientsapi/schema/record.py
+++ b/src/yclientsapi/schema/record.py
@@ -45,7 +45,7 @@ class RecordClient:
     success_visits_count: int | None = None
     fail_visits_count: int | None = None
     discount: int | None = None
-    custom_fields: list[dict] | None = None
+    custom_fields: dict | None = None
     client_tags: list[dict] | None = None
     is_new: bool | None = None
 
@@ -118,7 +118,6 @@ class Record:
     custom_font_color: str
     record_labels: list[RecordLabel]
     activity_id: int
-    custom_fields: list[dict]
     documents: list[RecordDocument]
     sms_remain_hours: int | None
     email_remain_hours: int | None
@@ -130,6 +129,7 @@ class Record:
     resource_instance_ids: list[int]
     short_link: str
     acceptance_free: str | None
+    custom_fields: dict | None = None
 
 
 @dataclass(config=Config.dataclass_config)

--- a/src/yclientsapi/schema/record.py
+++ b/src/yclientsapi/schema/record.py
@@ -45,7 +45,7 @@ class RecordClient:
     success_visits_count: int | None = None
     fail_visits_count: int | None = None
     discount: int | None = None
-    custom_fields: dict | list[dict] | None = None
+    custom_fields: list[dict] | None = None
     client_tags: list[dict] | None = None
     is_new: bool | None = None
 
@@ -118,6 +118,7 @@ class Record:
     custom_font_color: str
     record_labels: list[RecordLabel]
     activity_id: int
+    custom_fields: list[dict]
     documents: list[RecordDocument]
     sms_remain_hours: int | None
     email_remain_hours: int | None
@@ -129,7 +130,6 @@ class Record:
     resource_instance_ids: list[int]
     short_link: str
     acceptance_free: str | None
-    custom_fields: dict | list[dict] | None = None
 
 
 @dataclass(config=Config.dataclass_config)

--- a/src/yclientsapi/schema/record.py
+++ b/src/yclientsapi/schema/record.py
@@ -45,7 +45,7 @@ class RecordClient:
     success_visits_count: int | None = None
     fail_visits_count: int | None = None
     discount: int | None = None
-    custom_fields: dict | None = None
+    custom_fields: dict | list[dict] | None = None
     client_tags: list[dict] | None = None
     is_new: bool | None = None
 
@@ -129,7 +129,7 @@ class Record:
     resource_instance_ids: list[int]
     short_link: str
     acceptance_free: str | None
-    custom_fields: dict | None = None
+    custom_fields: dict | list[dict] | None = None
 
 
 @dataclass(config=Config.dataclass_config)

--- a/src/yclientsapi/schema/webhook.py
+++ b/src/yclientsapi/schema/webhook.py
@@ -45,7 +45,7 @@ class Client:
     success_visits_count: int
     fail_visits_count: int
     discount: int
-    custom_fields: list[dict]  # TODO: add nested schema
+    custom_fields: dict | None = None
     sex: int
     birthday: str
     client_tags: list[dict]  # TODO: add nested schema
@@ -119,7 +119,6 @@ class Webhook:
     custom_font_color: str
     record_labels: list[RecordLabel]
     activity_id: int
-    custom_fields: list[dict]  # TODO: add nested schema
     documents: list[Document]
     sms_remain_hours: int
     email_remain_hours: int
@@ -127,6 +126,7 @@ class Webhook:
     record_from: str
     is_mobile: int
     short_link: str
+    custom_fields: dict | None = None
 
 
 @dataclass(config=Config.dataclass_config)


### PR DESCRIPTION
## Summary

YClients webhook sends `custom_fields` as dict, not list[dict]. Keep `record.list()` API responses unchanged.

## Changes

In `src/yclientsapi/schema/webhook.py`:
- `Client.custom_fields`: `list[dict]` → `dict | None = None`
- `Webhook.custom_fields`: `list[dict]` → moved to end as `dict | None = None`

Record API responses in `record.py` remain `list[dict]` to support existing behavior.

Fixes #32